### PR TITLE
Username & Password for FTP Upload Bugfix

### DIFF
--- a/jspeedtest/src/main/java/fr/bmartel/speedtest/SpeedTestTask.java
+++ b/jspeedtest/src/main/java/fr/bmartel/speedtest/SpeedTestTask.java
@@ -1073,7 +1073,7 @@ public class SpeedTestTask {
             String pwd = SpeedTestConst.FTP_DEFAULT_PASSWORD;
 
             if (userInfo != null && userInfo.indexOf(':') != -1) {
-                user = userInfo.substring(0, userInfo.indexOf(':') - 1);
+                user = userInfo.substring(0, userInfo.indexOf(':'));
                 pwd = userInfo.substring(userInfo.indexOf(':') + 1);
             }
 


### PR DESCRIPTION
I've found a small bug.
Currently, the ftp upload method with username and password doesn't work.

I found that this line: 
user = userInfo.substring(0, userInfo.indexOf(':'));
lose the last character of the username.


I suggest fixing it like this:
user = userInfo.substring(0, userInfo.indexOf(':'));

Sorry for my bad english.

@tiwiz @bertrandmartel 